### PR TITLE
Auto publishing to S3 bucket

### DIFF
--- a/.github/workflows/publish_to_s3.yml
+++ b/.github/workflows/publish_to_s3.yml
@@ -1,0 +1,82 @@
+name: Build and Publish to S3
+
+on:
+  # Trigger after catalog rebuild workflow completes
+  workflow_run:
+    workflows: ["Run Make on modulefiles and tools change (GitHub App)"]
+    types:
+      - completed
+    branches:
+      - main
+      - auto_publish
+
+  # Trigger on push to main, but exclude paths that trigger catalog rebuild
+  # This prevents double-builds when catalog is updated
+  push:
+    branches:
+      - main
+      - auto_publish
+    paths-ignore:
+      - 'modulefiles/**'
+      - 'tools/**'
+
+  # Manual trigger for testing
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    # Only run if workflow_run was successful or if triggered manually/by push
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Build MkDocs site
+        run: mkdocs build --strict --verbose
+
+      - name: Install AWS CLI
+        run: |
+          pip install awscli
+
+      - name: Configure AWS credentials for Ceph S3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_KEY }}
+        run: |
+          aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
+          aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+          aws configure set default.region us-east-1
+          aws configure set default.s3.signature_version s3v4
+
+      - name: Sync to S3 bucket
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_KEY }}
+        run: |
+          aws s3 sync site/ s3://rcac-docs/ \
+            --endpoint-url https://s3.rcac.purdue.edu \
+            --acl public-read \
+            --delete \
+            --exclude ".git/*" \
+            --exclude ".github/*"
+
+      - name: Deployment completed
+        run: |
+          echo "-- Done --"

--- a/.github/workflows/publish_to_s3.yml
+++ b/.github/workflows/publish_to_s3.yml
@@ -49,7 +49,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Build MkDocs site
-        run: mkdocs build --strict --verbose
+        run: mkdocs build --verbose
 
       - name: Install AWS CLI
         run: |

--- a/WARP.md
+++ b/WARP.md
@@ -1,0 +1,217 @@
+# RCAC Documentation Website
+
+## Project Overview
+This is the MkDocs-based documentation website for the **Rosen Center for Advanced Computing (RCAC)** at Purdue University. It provides comprehensive user guides, tutorials, reference material, software catalogs, datasets, blog articles, and workshop materials for RCAC's HPC systems (Anvil and Gautschi).
+
+**Primary URL**: https://rcac-docs-demo.readthedocs.io
+
+## Repository Structure
+
+```
+RCAC-Docs/
+├── .github/workflows/        # GitHub Actions automation
+├── docs/                     # Main documentation content
+│   ├── assets/              # Images, CSS, JS, data files
+│   ├── blog/                # Blog posts
+│   ├── datasets/            # Dataset documentation
+│   ├── software/            # Software catalog pages
+│   ├── userguides/          # User guides (Anvil, Gautschi)
+│   ├── workshops/           # Workshop materials (HPC Exchange)
+│   ├── snippets/            # Reusable content snippets
+│   ├── contact.md           # Contact page
+│   ├── index.md             # Homepage
+│   └── templates.md         # Template examples
+├── hooks/                    # MkDocs hooks (e.g., social media)
+├── modulefiles/             # HPC module files (software installations)
+├── overrides/               # Material theme customizations
+├── tools/                   # Automation scripts for software catalog
+├── main.py                  # MkDocs macros plugin definitions
+├── mkdocs.yml               # MkDocs configuration
+├── requirements.txt         # Python dependencies
+└── .readthedocs.yaml        # Read the Docs configuration
+```
+
+## Technology Stack
+
+### Core Technologies
+- **MkDocs**: Static site generator (v1.6.1)
+- **Material for MkDocs**: Theme (v9.6.16)
+- **Python 3.x**: Runtime environment
+- **GitHub Actions**: CI/CD automation
+
+### Key MkDocs Plugins
+- `mkdocs-material`: Material Design theme
+- `mkdocs-blog-plugin`: Blog functionality
+- `mkdocs-git-revision-date-localized-plugin`: Git-based timestamps
+- `mkdocs-macros-plugin`: Dynamic content macros
+- `search`: Built-in search
+- `tags`: Content tagging
+
+### Markdown Extensions
+- `pymdownx`: Enhanced markdown features (code highlighting, tabs, details, emoji)
+- `admonition`: Callout boxes
+- `tables`: Table support
+- `attr_list`: HTML attributes in markdown
+- `toc`: Table of contents with permalinks
+
+## Content Organization
+
+### Major Sections
+1. **HPC User Guides**: Comprehensive guides for Anvil and Gautschi clusters
+2. **Blog**: News and updates categorized by system/topic
+3. **Software Catalog**: Auto-generated catalog of available software
+4. **Datasets**: Available datasets (AI, hydrological, meteorological, geospatial)
+5. **Workshops**: Training materials (HPC Exchange series)
+
+### Software Catalog System
+The software catalog is **automatically generated** from HPC module files:
+
+**Process Flow**:
+1. `modulefiles/` → Module files for installed software
+2. `tools/update_apps_inventory.sh` → Extracts app names, versions, clusters
+3. `tools/generate_apps_topics.py` → Categorizes apps by topic
+4. `tools/gen_apps_descriptions.py` → Fetches descriptions from Spack/Wikipedia/PyPI
+5. `tools/generate_md.sh` → Creates individual markdown files
+6. `tools/update_apps_catalog.sh` → Updates catalog index page
+
+**Topics**: MPI, Compilers, Chemistry, Fluid Dynamics, Geoscience, Math/Stats, Engineering, Utilities, Workflow, etc.
+
+## Automation & Workflows
+
+### GitHub Actions
+
+#### 1. **rebuild_on_module_tools_change.yml**
+- **Triggers**: Push to `main` branch when `modulefiles/**` or `tools/**` change
+- **Purpose**: Automatically regenerate software catalog
+- **Process**:
+  1. Runs `make` in `tools/` directory
+  2. Commits updated catalog files to repository
+  3. Uses GitHub App authentication (`purduercac-docs-bot`)
+- **Updates**: `docs/software/apps_md/`, `app_catalog.md`, `index.md`
+
+#### 2. **update_breadcrumbs.yml**
+- **Triggers**: Push to `main` branch when `mkdocs.yml` changes
+- **Purpose**: Regenerate navigation breadcrumbs
+- **Process**:
+  1. Runs `tools/generate_breadcrumbs.py`
+  2. Updates `docs/assets/data/breadcrumbs.json`
+  3. Commits changes automatically
+- **Logic**: Only includes parent titles if parent has an `index.md`
+
+### GitHub App Bot
+- **Name**: `purduercac-docs-bot`
+- **Purpose**: Automated commits to avoid triggering recursive workflows
+- **Configuration**: Uses app ID and private key from repository secrets
+
+### Read the Docs Integration
+- Configured via `.readthedocs.yaml`
+- Automatically builds and deploys on push to `main`
+- Uses Ubuntu 24.04 with Python 3
+
+## Development Workflow
+
+### Local Development Setup
+```bash
+# Clone repository
+git clone git@github.com:PurdueRCAC/RCAC-Docs.git
+cd RCAC-Docs
+
+# Create conda environment
+conda create -n rcac-docs python
+conda activate rcac-docs
+
+# Install dependencies
+python -m pip install -r requirements.txt
+
+# Start local server
+mkdocs serve              # Default: localhost:8000
+mkdocs serve -a localhost:8080  # Custom port
+```
+
+### Making Changes
+
+#### Content Changes
+1. Edit markdown files in `docs/`
+2. Test locally with `mkdocs serve`
+3. Commit and push to `main`
+4. Automatic deployment to Read the Docs
+
+#### Software Catalog Updates
+1. Add/modify module files in `modulefiles/`
+2. Push to `main` branch
+3. GitHub Action automatically runs `make` to regenerate catalog
+4. Bot commits updated catalog files
+
+#### Navigation Changes
+1. Edit `nav:` section in `mkdocs.yml`
+2. Push to `main` branch
+3. GitHub Action automatically regenerates breadcrumbs
+
+### Manual Catalog Generation
+```bash
+cd tools
+make  # Runs all steps in correct order
+
+# Or run individually:
+./update_apps_inventory.sh -v
+./generate_apps_topics.py
+./update_apps_descriptions_from_inventory.sh
+./generate_md.sh
+./update_apps_catalog.sh
+```
+
+## Special Features
+
+### MkDocs Macros (`main.py`)
+Reusable content snippets defined as Python functions:
+- `login_snippet()`: SSH login instructions
+- `account_snippet()`: Account creation info
+- `ssh_keys_snippet()`: SSH key setup guide
+- `ssh_x11_snippet()`: X11 forwarding setup
+- `thinlinc_snippet()`: ThinLinc client instructions
+
+### Theme Customizations
+- **Logo**: Purdue branding (`assets/purdue.png`)
+- **Color Schemes**: Light/dark/auto with Material Design
+- **Fonts**: Roboto (text), Consolas (code)
+- **Custom CSS**: `stylesheets/extra.css`
+- **Custom JS**: Table filtering, breadcrumbs
+
+### Analytics
+- Google Analytics (property: G-3D80JBWGP0)
+- Page feedback widget (thumbs up/down)
+
+## Best Practices
+
+### Content
+- Use admonitions for important notes/warnings
+- Include code blocks with proper syntax highlighting
+- Link to related pages within user guides
+- Tag blog posts with appropriate categories (Anvil, Gautschi, Software, Slurm, Workflows)
+
+### Version Control
+- All automated commits include co-author: `Co-Authored-By: Warp <agent@warp.dev>`
+- Bot commits use: `purduercac-docs-bot@users.noreply.github.com`
+
+### Testing
+- Always test locally before pushing to `main`
+- Check that breadcrumbs render correctly after `mkdocs.yml` changes
+- Verify software catalog after module file changes
+
+## Future Enhancements
+- **S3 Deployment**: Planned workflow to deploy to S3 bucket on `main` branch merge
+- Additional automation opportunities as needed
+
+## Key Files Reference
+- `mkdocs.yml`: Main configuration, navigation, plugins
+- `requirements.txt`: Python dependencies
+- `main.py`: MkDocs macros
+- `tools/Makefile`: Software catalog build automation
+- `.github/workflows/`: CI/CD automation
+- `.readthedocs.yaml`: Read the Docs build config
+
+## Contact
+- **Organization**: Rosen Center for Advanced Computing
+- **Email**: rcac-help@purdue.edu
+- **GitHub**: https://github.com/PurdueRCAC
+- **Discord**: https://discord.gg/RmtKZmaQW9

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -203,13 +203,6 @@ extra:
           note: >-
             Thanks for your feedback! Help us improve this page by using our <a href="https://github.com/Guangzhen-Jin/rcac-docs/issues/new?labels=feedback&title=[Feedback]:%20&body=>%20**Page%20Affected:**%20https://rcac-docs-demo.readthedocs.io{url}%0A>%20Please%20describe%20the%20issue%20you%20found%20on%20this%20page.%0A%0A" target="_blank" rel="noopener">feedback form</a>.
 
-features:
-  - search.suggest
-  - search.highlight
-  - search.share
-  - navigation.top
-  - navigation.tabs
-
 markdown_extensions:
   - toc:
       permalink: true


### PR DESCRIPTION
I've got this on a special `auto_publish` branch right now. The workflow completes and we're automatically building and syncing to our S3 bucket. A few things though that I want to highlight:

1. The software catalog build workflow triggers on push/merge to `main` branch which then re-commits and pushes back to that `main` branch. Therefore, my trigger for this workflow was set to run when that workflow runs so we don't end up in a recursive nightmare with these build-publish cycles.
2. If we're happy with this, I can do one more commit before we merge to clean up the `auto_publish` branch trigger since we're merging into `main`.
3. There's a manual trigger that gives us a button to press to trigger the build and publish workflow.

I think we could have more of a discussion on how to manage these two colliding workflows, but generally I think we're in good shape here.