### PR TITLE
Fixed typo on creating_the_submission_script.md

### DIFF
--- a/docs/userguides/gautschi/run_jobs/creating_the_submission_script.md
+++ b/docs/userguides/gautschi/run_jobs/creating_the_submission_script.md
@@ -8,7 +8,7 @@ search:
   boost: 2
 ---
 
-# Creatting the Slurm Job Submission Script
+# Creating the Slurm Job Submission Script
 
 To submit work to a SLURM queue, you must first create a job submission file. This job submission file is essentially a simple shell script that includes special comments to specify sbatch options. It will set any required environment variables, load any necessary modules, create or modify files and directories, and run any applications that you need. A simple submission script to the {{ resource }} cpu partition looks like:
 


### PR DESCRIPTION
There is a typo in the page header/title on this page: https://docs.rcac.purdue.edu/userguides/gautschi/run_jobs/creating_the_submission_script/

I fixed the typo in this commit