### PR TITLE
Add quick launcher buttons to HPC cluster index pages

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -632,3 +632,64 @@ th, td {
 .md-header__source {
   display: none;
 }
+
+/* ── Quick Launcher Cards ─────────────────────────────────────── */
+.quick-launcher {
+  display: flex;
+  gap: 1rem;
+  margin: 1rem 0 1.5rem;
+  flex-wrap: wrap;
+}
+
+.quick-launcher-card {
+  flex: 0 0 auto;
+  width: 250px;
+  border: 2px solid rgba(0, 0, 0, 0.25);
+  border-radius: 6px;
+  padding: 0.6rem 0.75rem 0.6rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  background: var(--md-default-bg-color);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+.quick-launcher-card .launcher-title {
+  font-weight: 700;
+  font-size: 0.8rem;
+  text-align: center;
+  color: var(--md-default-fg-color);
+}
+
+.quick-launcher-card .launcher-btn {
+  display: block;
+  width: 100%;
+  padding: 0.45rem 0;
+  text-align: center;
+  background-color: #CBBA94;
+  color: #3d2e0e !important;
+  text-decoration: none !important;
+  border-radius: 4px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  transition: background-color 0.15s;
+}
+
+.quick-launcher-card .launcher-btn:hover {
+  background-color: #b8a57e;
+}
+
+[data-md-color-scheme="slate"] .quick-launcher-card {
+  border-color: rgba(255, 255, 255, 0.3);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+}
+
+[data-md-color-scheme="slate"] .quick-launcher-card .launcher-btn {
+  background-color: #CBBA94;
+  color: #1a1200 !important;
+}
+
+[data-md-color-scheme="slate"] .quick-launcher-card .launcher-btn:hover {
+  background-color: #ddd0b0;
+}

--- a/docs/userguides/anvil/index.md
+++ b/docs/userguides/anvil/index.md
@@ -1,4 +1,20 @@
+---
+tags:
+   - Anvil
+authors:
+  - jin456
+search:
+  boost: 2
+---
+
 # Anvil User Guide
+
+<div class="quick-launcher">
+  <div class="quick-launcher-card">
+    <span class="launcher-title">Gateway (Open OnDemand)</span>
+    <a href="https://ondemand.anvil.rcac.purdue.edu/" class="launcher-btn" target="_blank" rel="noopener">Launch</a>
+  </div>
+</div>
 
 ## About Anvil
 

--- a/docs/userguides/bell/index.md
+++ b/docs/userguides/bell/index.md
@@ -9,6 +9,18 @@ search:
 ---
 
 # Bell User Guide
+
+<div class="quick-launcher">
+  <div class="quick-launcher-card">
+    <span class="launcher-title">Gateway (Open OnDemand)</span>
+    <a href="https://gateway.bell.rcac.purdue.edu/" class="launcher-btn" target="_blank" rel="noopener">Launch</a>
+  </div>
+  <div class="quick-launcher-card">
+    <span class="launcher-title">Remote Desktop (ThinLinc)</span>
+    <a href="https://desktop.bell.rcac.purdue.edu/" class="launcher-btn" target="_blank" rel="noopener">Launch</a>
+  </div>
+</div>
+
 Bell is a Community Cluster optimized for communities running traditional, tightly-coupled science and engineering applications.
 
 - [**Bell Overview**](overview.md)

--- a/docs/userguides/gautschi/index.md
+++ b/docs/userguides/gautschi/index.md
@@ -1,6 +1,6 @@
 ---
-# tags:
-#   - Gautschi
+tags:
+  - Gautschi
 authors:
   - jin456
 search:
@@ -8,6 +8,18 @@ search:
 ---
 
 # Gautschi User Guide
+
+<div class="quick-launcher">
+  <div class="quick-launcher-card">
+    <span class="launcher-title">Gateway (Open OnDemand)</span>
+    <a href="https://gateway.gautschi.rcac.purdue.edu/" class="launcher-btn" target="_blank" rel="noopener">Launch</a>
+  </div>
+  <div class="quick-launcher-card">
+    <span class="launcher-title">Remote Desktop (ThinLinc)</span>
+    <a href="https://desktop.gautschi.rcac.purdue.edu/" class="launcher-btn" target="_blank" rel="noopener">Launch</a>
+  </div>
+</div>
+
 Gautschi is a Community Cluster optimized for communities running traditional, tightly-coupled science and engineering applications.
 
 - [**Gautschi Overview**](overview.md)

--- a/docs/userguides/gilbreth/index.md
+++ b/docs/userguides/gilbreth/index.md
@@ -1,6 +1,6 @@
 ---
-# tags:
-#   - Gilbreth
+tags:
+  - Gilbreth
 authors:
   - jin456
 search:
@@ -8,6 +8,17 @@ search:
 ---
 
 # Gilbreth User Guide
+
+<div class="quick-launcher">
+  <div class="quick-launcher-card">
+    <span class="launcher-title">Gateway (Open OnDemand)</span>
+    <a href="https://gateway.gilbreth.rcac.purdue.edu/" class="launcher-btn" target="_blank" rel="noopener">Launch</a>
+  </div>
+  <div class="quick-launcher-card">
+    <span class="launcher-title">Remote Desktop (ThinLinc)</span>
+    <a href="https://desktop.gilbreth.rcac.purdue.edu/" class="launcher-btn" target="_blank" rel="noopener">Launch</a>
+  </div>
+</div>
 
 Gilbreth is a Community Cluster optimized for communities running GPU intensive applications such as machine learning.
 

--- a/docs/userguides/scholar/index.md
+++ b/docs/userguides/scholar/index.md
@@ -9,6 +9,18 @@ search:
 ---
 
 # Scholar User Guide
+
+<div class="quick-launcher">
+  <div class="quick-launcher-card">
+    <span class="launcher-title">Gateway (Open OnDemand)</span>
+    <a href="https://gateway.scholar.rcac.purdue.edu/" class="launcher-btn" target="_blank" rel="noopener">Launch</a>
+  </div>
+  <div class="quick-launcher-card">
+    <span class="launcher-title">Remote Desktop (ThinLinc)</span>
+    <a href="https://desktop.scholar.rcac.purdue.edu/" class="launcher-btn" target="_blank" rel="noopener">Launch</a>
+  </div>
+</div>
+
 Scholar is a small computer cluster, suitable for classroom learning about high performance computing (HPC).
 
 - [**Scholar Overview**](overview.md)


### PR DESCRIPTION
Adds Gateway (Open OnDemand) and Remote Desktop (ThinLinc) launch buttons to Gautschi, Bell, Gilbreth, and Scholar index pages; Gateway-only for Anvil.